### PR TITLE
Fixup/repeated names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ wca-developer-database-dump*
 
 log/
 
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Tests use docker database to simulate the whole process.
 
 `./gradlew test`
 
+_Note_: If you are running on Mac M1, maybe you will have issues starting docker. To try to fix it, you may add `platform: linux/x86_64` to the service `wca-test-db` in the file `docker-compose-test.yml`.
+
 ## Project details
 
 This project uses [Gradle](https://gradle.org/) as the build system. It was built using [Spring Boot](https://spring.io/projects/spring-boot), an awesome framework also for building batches/jobs.

--- a/src/main/java/org/worldcubeassociation/dbsanitycheck/service/impl/WrtSanityCheckServiceImpl.java
+++ b/src/main/java/org/worldcubeassociation/dbsanitycheck/service/impl/WrtSanityCheckServiceImpl.java
@@ -8,8 +8,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.worldcubeassociation.dbsanitycheck.bean.AnalysisBean;
 import org.worldcubeassociation.dbsanitycheck.bean.SanityCheckWithErrorBean;
-import org.worldcubeassociation.dbsanitycheck.model.SanityCheck;
 import org.worldcubeassociation.dbsanitycheck.model.Exclusion;
+import org.worldcubeassociation.dbsanitycheck.model.SanityCheck;
 import org.worldcubeassociation.dbsanitycheck.repository.SanityCheckRepository;
 import org.worldcubeassociation.dbsanitycheck.service.EmailService;
 import org.worldcubeassociation.dbsanitycheck.service.WrtSanityCheckService;
@@ -45,7 +45,6 @@ public class WrtSanityCheckServiceImpl implements WrtSanityCheckService {
 
         log.info("Reading queries");
 
-        // Read queryes
         List<SanityCheck> sanityChecks = sanityCheckRepository
                 .findAll(Sort.by(Sort.Direction.ASC, "sanityCheckCategoryId", "topic"));
         log.info("Found {} queries", sanityChecks.size());
@@ -100,7 +99,7 @@ public class WrtSanityCheckServiceImpl implements WrtSanityCheckService {
 
                 // The column count starts from 1
                 for (int i = 1; i <= columnCount; i++) {
-                    String name = rsmd.getColumnName(i);
+                    String name = rsmd.getColumnLabel(i);
 
                     if (columnsConsidered.contains(name)) {
                         throw new RuntimeException("Column " + name + " is duplicated");
@@ -145,7 +144,7 @@ public class WrtSanityCheckServiceImpl implements WrtSanityCheckService {
         List<JSONObject> remains = result.stream().filter(it -> !compareExistingKeys(it, exclusions))
                 .collect(Collectors.toList());
 
-        if (exclusions.size() > result.size()){
+        if (exclusions.size() > result.size()) {
             log.info("You have more exclusions than results, check the exclusions.");
         }
 

--- a/src/test/resources/responses/wrt-sanity-check-service-test/regularWorkflow.html
+++ b/src/test/resources/responses/wrt-sanity-check-service-test/regularWorkflow.html
@@ -9,7 +9,7 @@
 
 <h2>Sanity Check Results</h2>
 
-<h4>Found inconsistencies in 1 topics.</h4>
+<h4>Found inconsistencies in 2 topics.</h4>
 
 <h3>1. [Person Data Irregularities] Names with numbers</h3>
 <div style="overflow-x: auto;">
@@ -31,6 +31,24 @@
     <td style="border: 1px solid black;">4</td>
     <td style="border: 1px solid black;">Czech Republic</td>
     <td style="border: 1px solid black;">5</td>
+   </tr>
+  </tbody>
+ </table>
+</div>
+<br>
+
+<h3>2. [User Data Irregularities] Inconsistent name in users table</h3>
+<div style="overflow-x: auto;">
+ <table style="border: 1px solid black;">
+  <thead>
+   <tr style="background-color: #f2f2f2;"><th scope="col" style="border: 1px solid black;">profile_name</th><th scope="col" style="border: 1px solid black;">account_name</th><th scope="col" style="border: 1px solid black;">id</th>
+   </tr>
+  </thead>
+  <tbody>
+   <tr>
+    <td style="border: 1px solid black;">Lola-Rose Nelson</td>
+    <td style="border: 1px solid black;">Lola Rose Nelson</td>
+    <td style="border: 1px solid black;">1982PETR01</td>
    </tr>
   </tbody>
  </table>

--- a/src/test/resources/test-scripts/cleanTestData.sql
+++ b/src/test/resources/test-scripts/cleanTestData.sql
@@ -4,5 +4,6 @@ truncate sanity_checks;
 truncate sanity_check_exclusions;
 truncate sanity_check_categories;
 truncate Persons;
+truncate users;
 
 set foreign_key_checks = 1;

--- a/src/test/resources/test-scripts/regularWorkflow.sql
+++ b/src/test/resources/test-scripts/regularWorkflow.sql
@@ -1,20 +1,320 @@
 -- Create categories
-insert into sanity_check_categories (id, name) values (1, 'Person Data Irregularities'), (2, 'Irregular Results');
+insert into
+    sanity_check_categories (id, name)
+values
+    (1, 'Person Data Irregularities'),
+    (2, 'Irregular Results');
 
 -- Insert sanity check
-insert into sanity_checks (id, sanity_check_category_id, topic, query) values (1, 1, 'Names with numbers', 'SELECT * FROM Persons WHERE name REGEXP \'[0-9]\'');
-insert into sanity_checks (id, sanity_check_category_id, topic, query) values (2, 1, 'Query with error', 'CELECT * FROM Persons WHERE name REGEXP \'[0-9]\'');
+insert into
+    sanity_checks (id, sanity_check_category_id, topic, query)
+values
+    (
+        1,
+        1,
+        'Names with numbers',
+        'SELECT * FROM Persons WHERE name REGEXP \'[0-9]\''
+    );
+
+insert into
+    sanity_checks (id, sanity_check_category_id, topic, query)
+values
+    (
+        2,
+        1,
+        'Query with error',
+        'CELECT * FROM Persons WHERE name REGEXP \'[0-9]\''
+    );
 
 -- Insert competitors. There's one competitor with number
-INSERT INTO wca_development.Persons (id, subId, name, countryId, gender, `year`, `month`, `day`, comments, rails_id, incorrect_wca_id_claim_count) VALUES('1982BORS01', 1, 'Elsie-May Talbot', 'Serbia', 'm', 1954, 12, 4, '', 1, 0);
-INSERT INTO wca_development.Persons (id, subId, name, countryId, gender, `year`, `month`, `day`, comments, rails_id, incorrect_wca_id_claim_count) VALUES('1982BRIN01', 1, 'Gianni Lozano', 'Germany', 'm', 1954, 12, 4, '', 2, 0);
-INSERT INTO wca_development.Persons (id, subId, name, countryId, gender, `year`, `month`, `day`, comments, rails_id, incorrect_wca_id_claim_count) VALUES('1982CHIL01', 1, 'Saif Chandler', 'United Kingdom', 'm', 1954, 12, 4, '', 3, 0);
-INSERT INTO wca_development.Persons (id, subId, name, countryId, gender, `year`, `month`, `day`, comments, rails_id, incorrect_wca_id_claim_count) VALUES('1982FRID01', 1, 'Dottie Marsh', 'USA', 'f', 1954, 12, 4, '', 4, 0);
-INSERT INTO wca_development.Persons (id, subId, name, countryId, gender, `year`, `month`, `day`, comments, rails_id, incorrect_wca_id_claim_count) VALUES('1982FRID01', 2, 'Dottie Marsh 2', 'Czech Republic', 'f', 1954, 12, 4, '', 5, 0);
-INSERT INTO wca_development.Persons (id, subId, name, countryId, gender, `year`, `month`, `day`, comments, rails_id, incorrect_wca_id_claim_count) VALUES('1982GALR01', 1, 'Colleen Scott', 'Portugal', 'm', 1954, 12, 4, '', 6, 0);
-INSERT INTO wca_development.Persons (id, subId, name, countryId, gender, `year`, `month`, `day`, comments, rails_id, incorrect_wca_id_claim_count) VALUES('1982JEAN01', 1, 'Ellie-Mai Swift', 'France', 'm', 1954, 12, 4, '', 7, 0);
-INSERT INTO wca_development.Persons (id, subId, name, countryId, gender, `year`, `month`, `day`, comments, rails_id, incorrect_wca_id_claim_count) VALUES('1982LABA01', 1, 'Lilli Sims', 'Hungary', 'm', 1954, 12, 4, '', 8, 0);
-INSERT INTO wca_development.Persons (id, subId, name, countryId, gender, `year`, `month`, `day`, comments, rails_id, incorrect_wca_id_claim_count) VALUES('1982LAET01', 1, 'Ignacy Snider', 'Belgium', 'm', 1954, 12, 4, '', 9, 0);
-INSERT INTO wca_development.Persons (id, subId, name, countryId, gender, `year`, `month`, `day`, comments, rails_id, incorrect_wca_id_claim_count) VALUES('1982PETR01', 1, 'Lola-Rose Nelson', 'Sweden', 'm', 1954, 12, 4, '', 10, 0);
--- names from https://www.name-generator.org.uk/quick/
+INSERT INTO
+    wca_development.Persons (
+        id,
+        subId,
+        name,
+        countryId,
+        gender,
+        `year`,
+        `month`,
+        `day`,
+        comments,
+        rails_id,
+        incorrect_wca_id_claim_count
+    )
+VALUES
+(
+        '1982BORS01',
+        1,
+        'Elsie-May Talbot',
+        'Serbia',
+        'm',
+        1954,
+        12,
+        4,
+        '',
+        1,
+        0
+    );
 
+INSERT INTO
+    wca_development.Persons (
+        id,
+        subId,
+        name,
+        countryId,
+        gender,
+        `year`,
+        `month`,
+        `day`,
+        comments,
+        rails_id,
+        incorrect_wca_id_claim_count
+    )
+VALUES
+(
+        '1982BRIN01',
+        1,
+        'Gianni Lozano',
+        'Germany',
+        'm',
+        1954,
+        12,
+        4,
+        '',
+        2,
+        0
+    );
+
+INSERT INTO
+    wca_development.Persons (
+        id,
+        subId,
+        name,
+        countryId,
+        gender,
+        `year`,
+        `month`,
+        `day`,
+        comments,
+        rails_id,
+        incorrect_wca_id_claim_count
+    )
+VALUES
+(
+        '1982CHIL01',
+        1,
+        'Saif Chandler',
+        'United Kingdom',
+        'm',
+        1954,
+        12,
+        4,
+        '',
+        3,
+        0
+    );
+
+INSERT INTO
+    wca_development.Persons (
+        id,
+        subId,
+        name,
+        countryId,
+        gender,
+        `year`,
+        `month`,
+        `day`,
+        comments,
+        rails_id,
+        incorrect_wca_id_claim_count
+    )
+VALUES
+(
+        '1982FRID01',
+        1,
+        'Dottie Marsh',
+        'USA',
+        'f',
+        1954,
+        12,
+        4,
+        '',
+        4,
+        0
+    );
+
+INSERT INTO
+    wca_development.Persons (
+        id,
+        subId,
+        name,
+        countryId,
+        gender,
+        `year`,
+        `month`,
+        `day`,
+        comments,
+        rails_id,
+        incorrect_wca_id_claim_count
+    )
+VALUES
+(
+        '1982FRID01',
+        2,
+        'Dottie Marsh 2',
+        'Czech Republic',
+        'f',
+        1954,
+        12,
+        4,
+        '',
+        5,
+        0
+    );
+
+INSERT INTO
+    wca_development.Persons (
+        id,
+        subId,
+        name,
+        countryId,
+        gender,
+        `year`,
+        `month`,
+        `day`,
+        comments,
+        rails_id,
+        incorrect_wca_id_claim_count
+    )
+VALUES
+(
+        '1982GALR01',
+        1,
+        'Colleen Scott',
+        'Portugal',
+        'm',
+        1954,
+        12,
+        4,
+        '',
+        6,
+        0
+    );
+
+INSERT INTO
+    wca_development.Persons (
+        id,
+        subId,
+        name,
+        countryId,
+        gender,
+        `year`,
+        `month`,
+        `day`,
+        comments,
+        rails_id,
+        incorrect_wca_id_claim_count
+    )
+VALUES
+(
+        '1982JEAN01',
+        1,
+        'Ellie-Mai Swift',
+        'France',
+        'm',
+        1954,
+        12,
+        4,
+        '',
+        7,
+        0
+    );
+
+INSERT INTO
+    wca_development.Persons (
+        id,
+        subId,
+        name,
+        countryId,
+        gender,
+        `year`,
+        `month`,
+        `day`,
+        comments,
+        rails_id,
+        incorrect_wca_id_claim_count
+    )
+VALUES
+(
+        '1982LABA01',
+        1,
+        'Lilli Sims',
+        'Hungary',
+        'm',
+        1954,
+        12,
+        4,
+        '',
+        8,
+        0
+    );
+
+INSERT INTO
+    wca_development.Persons (
+        id,
+        subId,
+        name,
+        countryId,
+        gender,
+        `year`,
+        `month`,
+        `day`,
+        comments,
+        rails_id,
+        incorrect_wca_id_claim_count
+    )
+VALUES
+(
+        '1982LAET01',
+        1,
+        'Ignacy Snider',
+        'Belgium',
+        'm',
+        1954,
+        12,
+        4,
+        '',
+        9,
+        0
+    );
+
+INSERT INTO
+    wca_development.Persons (
+        id,
+        subId,
+        name,
+        countryId,
+        gender,
+        `year`,
+        `month`,
+        `day`,
+        comments,
+        rails_id,
+        incorrect_wca_id_claim_count
+    )
+VALUES
+(
+        '1982PETR01',
+        1,
+        'Lola-Rose Nelson',
+        'Sweden',
+        'm',
+        1954,
+        12,
+        4,
+        '',
+        10,
+        0
+    );
+
+-- names from https://www.name-generator.org.uk/quick/

--- a/src/test/resources/test-scripts/regularWorkflow.sql
+++ b/src/test/resources/test-scripts/regularWorkflow.sql
@@ -3,7 +3,8 @@ insert into
     sanity_check_categories (id, name)
 values
     (1, 'Person Data Irregularities'),
-    (2, 'Irregular Results');
+    (2, 'Irregular Results'),
+    (3, 'User Data Irregularities');
 
 -- Insert sanity check
 insert into
@@ -20,6 +21,12 @@ values
         1,
         'Query with error',
         'CELECT * FROM Persons WHERE name REGEXP \'[0-9]\''
+    ),
+    (
+        3,
+        3,
+        'Inconsistent name in users table',
+        'SELECT p.id, p.name as profile_name, u.name as account_name FROM Persons p INNER JOIN users u ON p.id=u.wca_id AND p.name<>u.name AND p.subId=1'
     );
 
 -- Insert competitors. There's one competitor with number
@@ -38,7 +45,7 @@ insert into
         incorrect_wca_id_claim_count
     )
 values
-(
+    (
         '1982BORS01',
         1,
         'Elsie-May Talbot',
@@ -51,7 +58,7 @@ values
         1,
         0
     ),
-(
+    (
         '1982BRIN01',
         1,
         'Gianni Lozano',
@@ -64,7 +71,7 @@ values
         2,
         0
     ),
-(
+    (
         '1982CHIL01',
         1,
         'Saif Chandler',
@@ -77,7 +84,7 @@ values
         3,
         0
     ),
-(
+    (
         '1982FRID01',
         1,
         'Dottie Marsh',
@@ -90,7 +97,7 @@ values
         4,
         0
     ),
-(
+    (
         '1982FRID01',
         2,
         'Dottie Marsh 2',
@@ -103,7 +110,7 @@ values
         5,
         0
     ),
-(
+    (
         '1982GALR01',
         1,
         'Colleen Scott',
@@ -116,7 +123,7 @@ values
         6,
         0
     ),
-(
+    (
         '1982JEAN01',
         1,
         'Ellie-Mai Swift',
@@ -129,7 +136,7 @@ values
         7,
         0
     ),
-(
+    (
         '1982LABA01',
         1,
         'Lilli Sims',
@@ -142,7 +149,7 @@ values
         8,
         0
     ),
-(
+    (
         '1982LAET01',
         1,
         'Ignacy Snider',
@@ -155,7 +162,7 @@ values
         9,
         0
     ),
-(
+    (
         '1982PETR01',
         1,
         'Lola-Rose Nelson',
@@ -170,3 +177,51 @@ values
     );
 
 -- names from https://www.name-generator.org.uk/quick/
+INSERT INTO
+    wca_development.users (
+        id,
+        email,
+        encrypted_password,
+        sign_in_count,
+        current_sign_in_at,
+        last_sign_in_at,
+        confirmed_at,
+        created_at,
+        updated_at,
+        name,
+        region,
+        wca_id,
+        avatar,
+        dob,
+        gender,
+        country_iso2,
+        results_notifications_enabled,
+        receive_delegate_reports,
+        dummy_account,
+        otp_required_for_login,
+        cookies_acknowledged
+    )
+values
+    (
+        6713,
+        '6713@worldcubeassociation.org',
+        '',
+        0,
+        '2017-04-03 19:13:42',
+        '2017-02-17 01:00:55',
+        '2015-11-24 19:43:41',
+        '2015-11-24 19:43:19',
+        '2017-04-03 19:13:42',
+        'Lola Rose Nelson',
+        '',
+        '1982PETR01',
+        '1489600485.jpg',
+        '1954-12-04',
+        'm',
+        'SE',
+        0,
+        0,
+        0,
+        0,
+        0
+    );

--- a/src/test/resources/test-scripts/regularWorkflow.sql
+++ b/src/test/resources/test-scripts/regularWorkflow.sql
@@ -14,11 +14,7 @@ values
         1,
         'Names with numbers',
         'SELECT * FROM Persons WHERE name REGEXP \'[0-9]\''
-    );
-
-insert into
-    sanity_checks (id, sanity_check_category_id, topic, query)
-values
+    ),
     (
         2,
         1,
@@ -27,7 +23,7 @@ values
     );
 
 -- Insert competitors. There's one competitor with number
-INSERT INTO
+insert into
     wca_development.Persons (
         id,
         subId,
@@ -41,7 +37,7 @@ INSERT INTO
         rails_id,
         incorrect_wca_id_claim_count
     )
-VALUES
+values
 (
         '1982BORS01',
         1,
@@ -54,23 +50,7 @@ VALUES
         '',
         1,
         0
-    );
-
-INSERT INTO
-    wca_development.Persons (
-        id,
-        subId,
-        name,
-        countryId,
-        gender,
-        `year`,
-        `month`,
-        `day`,
-        comments,
-        rails_id,
-        incorrect_wca_id_claim_count
-    )
-VALUES
+    ),
 (
         '1982BRIN01',
         1,
@@ -83,23 +63,7 @@ VALUES
         '',
         2,
         0
-    );
-
-INSERT INTO
-    wca_development.Persons (
-        id,
-        subId,
-        name,
-        countryId,
-        gender,
-        `year`,
-        `month`,
-        `day`,
-        comments,
-        rails_id,
-        incorrect_wca_id_claim_count
-    )
-VALUES
+    ),
 (
         '1982CHIL01',
         1,
@@ -112,23 +76,7 @@ VALUES
         '',
         3,
         0
-    );
-
-INSERT INTO
-    wca_development.Persons (
-        id,
-        subId,
-        name,
-        countryId,
-        gender,
-        `year`,
-        `month`,
-        `day`,
-        comments,
-        rails_id,
-        incorrect_wca_id_claim_count
-    )
-VALUES
+    ),
 (
         '1982FRID01',
         1,
@@ -141,23 +89,7 @@ VALUES
         '',
         4,
         0
-    );
-
-INSERT INTO
-    wca_development.Persons (
-        id,
-        subId,
-        name,
-        countryId,
-        gender,
-        `year`,
-        `month`,
-        `day`,
-        comments,
-        rails_id,
-        incorrect_wca_id_claim_count
-    )
-VALUES
+    ),
 (
         '1982FRID01',
         2,
@@ -170,23 +102,7 @@ VALUES
         '',
         5,
         0
-    );
-
-INSERT INTO
-    wca_development.Persons (
-        id,
-        subId,
-        name,
-        countryId,
-        gender,
-        `year`,
-        `month`,
-        `day`,
-        comments,
-        rails_id,
-        incorrect_wca_id_claim_count
-    )
-VALUES
+    ),
 (
         '1982GALR01',
         1,
@@ -199,23 +115,7 @@ VALUES
         '',
         6,
         0
-    );
-
-INSERT INTO
-    wca_development.Persons (
-        id,
-        subId,
-        name,
-        countryId,
-        gender,
-        `year`,
-        `month`,
-        `day`,
-        comments,
-        rails_id,
-        incorrect_wca_id_claim_count
-    )
-VALUES
+    ),
 (
         '1982JEAN01',
         1,
@@ -228,23 +128,7 @@ VALUES
         '',
         7,
         0
-    );
-
-INSERT INTO
-    wca_development.Persons (
-        id,
-        subId,
-        name,
-        countryId,
-        gender,
-        `year`,
-        `month`,
-        `day`,
-        comments,
-        rails_id,
-        incorrect_wca_id_claim_count
-    )
-VALUES
+    ),
 (
         '1982LABA01',
         1,
@@ -257,23 +141,7 @@ VALUES
         '',
         8,
         0
-    );
-
-INSERT INTO
-    wca_development.Persons (
-        id,
-        subId,
-        name,
-        countryId,
-        gender,
-        `year`,
-        `month`,
-        `day`,
-        comments,
-        rails_id,
-        incorrect_wca_id_claim_count
-    )
-VALUES
+    ),
 (
         '1982LAET01',
         1,
@@ -286,23 +154,7 @@ VALUES
         '',
         9,
         0
-    );
-
-INSERT INTO
-    wca_development.Persons (
-        id,
-        subId,
-        name,
-        countryId,
-        gender,
-        `year`,
-        `month`,
-        `day`,
-        comments,
-        rails_id,
-        incorrect_wca_id_claim_count
-    )
-VALUES
+    ),
 (
         '1982PETR01',
         1,


### PR DESCRIPTION
Simple fix. Row mapper was ignoring the column alias and always considering the original column name. We are changing this behavior. From now on, we are (correctly) getting column alias.